### PR TITLE
[Refactor] Add more param to sql run

### DIFF
--- a/.github/hypertrons-components/auto_update_report/defaultConfig.ts
+++ b/.github/hypertrons-components/auto_update_report/defaultConfig.ts
@@ -26,6 +26,9 @@ const defaultConfig: Config = {
   defaultRenderParams: {
     year: 2020,
     table: 'github_log.year2020',
+    owner: 'X-lab2017',
+    repo: 'github-analysis-report',
+    baseUrl: 'http://gar2020.opensource-service.cn/',
   },
   sqlRequestUrl: 'http://localhost:7001/query',
   // report

--- a/.github/hypertrons-components/sql_run/defaultConfig.ts
+++ b/.github/hypertrons-components/sql_run/defaultConfig.ts
@@ -23,6 +23,9 @@ const defaultConfig: Config = {
   defaultRenderParams: {
     year: 2020,
     table: 'github_log.year2020',
+    owner: 'X-lab2017',
+    repo: 'github-analysis-report',
+    baseUrl: 'http://gar2020.opensource-service.cn/',
   },
   commentItemTemplate: `I found SQL component \`{{sqlName}}\` in this PR, the SQL run result data is:
 \`\`\`

--- a/.github/hypertrons-components/sql_run/index.lua
+++ b/.github/hypertrons-components/sql_run/index.lua
@@ -75,7 +75,7 @@ on('CommandEvent', function (e)
             ['query'] = sql
           }
         })
-        local text = runJsCode(v.postProcessor, string2table(requestRes).data)
+        local text = runJsCode(v.postProcessor, string2table(requestRes).data, compConfig.defaultRenderParams)
         log('Sql run done for '..k)
         comment = comment..rendStr(compConfig.commentItemTemplate, {
           ['text'] = text,


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Add `owner`, `repo`, `baseUrl` for `sql-run` and `auto-update-report` component. 

Also add default config to `runJsCode` so `post-processor` can get the params.

This PR should be merged before #89 