### PR TITLE
[Docs] Add working hour to report template

### DIFF
--- a/REPORT_TEMPLATE.md
+++ b/REPORT_TEMPLATE.md
@@ -1,3 +1,9 @@
 # GitHub Analysis Report
 
 We anaylsis {{sqls.total-record-count.text}} records of GitHub logs, there are {{sqls.total-repo-count.text}} active repositories and {{sqls.total-developer-count.text}} active developers on GitHub during year {{year}}.
+
+## Working Hour Distribution
+
+We analyze the working hour distribution for GitHub logs all over the world during year {{year}}, we found that open source developers are predominantly European because local working hour period lays in UTC±1 as the image shows.
+
+<embed src="{{sqls.working-hour-distribution.text}}?lang=en" style="width:100%" />


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Relate to #89 

Add simple working hour description into template.

BTW, if we want to insert an `svg` image into markdown file, need to use `embed` tag because default way to add an image will convert to `img` tag which does not support `svg` dynamic functions. 