### PR TITLE
Add a link to associate the project homepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # GitHub Analysis Report
 
-GitHub analysis report is an open source analysis report project for GitHub initiated by [X-lab](https://x-lab.info), this project aims to combine the wisdom of global developers to jointly analyze and insight into GitHub's developer behavior data to help everyone better understand and participate in open source.
+[GitHub analysis report](https://github.com/X-lab2017/github-analysis-report) is an open source analysis report project for GitHub initiated by [X-lab](https://x-lab.info), this project aims to combine the wisdom of global developers to jointly analyze and insight into GitHub's developer behavior data to help everyone better understand and participate in open source.
 
 ## Data
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -1,6 +1,6 @@
 # GitHub 全域数字报告
 
-GitHub 数字全域报告是由 X-lab 发起的一个 GitHub 数字分析报告开源项目，这个项目旨在凝聚全球开发者的智慧共同对 GitHub 全域行为日志数据进行分析统计，以使开发者可以更好的理解和参与开源。
+[GitHub 数字全域报告](https://github.com/X-lab2017/github-analysis-report) 是由 X-lab 发起的一个 GitHub 数字分析报告开源项目，这个项目旨在凝聚全球开发者的智慧共同对 GitHub 全域行为日志数据进行分析统计，以使开发者可以更好的理解和参与开源。
 
 ## 数据
 


### PR DESCRIPTION
There is no link what links to the project homepage in the [GitHub Analysis Report](https://www.x-lab.info/github-analysis-report/#/).