### PR TITLE
sqls: add sql of release analysis (#277)

### DIFF
--- a/.autogit/autogit.json
+++ b/.autogit/autogit.json
@@ -1,0 +1,5 @@
+{
+  "updateInterval": 1800,
+  "logging": true,
+  "silent": true
+}

--- a/sqls/release-analysis/manifest.json
+++ b/sqls/release-analysis/manifest.json
@@ -1,0 +1,4 @@
+{
+  "config": {},
+  "description": "Return the total releases count, last release time, average interval and average body length of every repo in year {{year}}"
+}

--- a/sqls/release-analysis/sql
+++ b/sqls/release-analysis/sql
@@ -1,0 +1,10 @@
+SELECT
+    repo_id,
+    COUNT(*) AS total_releases_count,
+    MAX(release_published_at) AS last_release_time,
+    365 / COUNT(*) AS average_interval,
+    AVG(LENGTH(release_body)) AS average_body_length
+FROM
+    {{table}}
+GROUP BY
+    repo_id


### PR DESCRIPTION
This sql returns the total releases count, last release time, average interval and average body length of every repo.

To display the result directly, I build a simple data case as below:

![图片](https://user-images.githubusercontent.com/40034603/103127870-200f1a00-46ce-11eb-9fb2-d5e90643f9b8.png)

The result which this sql returns will be like below.

![图片](https://user-images.githubusercontent.com/40034603/103127965-75e3c200-46ce-11eb-81dc-0f2af60eb509.png)

I’m not so sure is this what we want in this feature or does this implementation fit the runtime environment. @frank-zsy 
