### PR TITLE
[Fix] fix issue comment event name

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,7 +1,7 @@
 name: pr-test
 
 on:
-  issue_comments:
+  issue_comment:
     types: [created]
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

The event name should be `issue_comment`